### PR TITLE
Fixes #295 - Removed light-table as dep, updated back to react-bootst…

### DIFF
--- a/packages/react-atlas-core/package.json
+++ b/packages/react-atlas-core/package.json
@@ -25,6 +25,7 @@
     "moment": "^2.19.1",
     "proptypes": "^1.0.0",
     "react": "^15.6.2",
+    "react-bootstrap-table": "4.3.1",
     "react-datepicker": "^0.60.2",
     "react-dom": "^15.6.2",
     "react-dropzone": "^4.2.1"

--- a/packages/react-atlas-core/src/Table/Table.js
+++ b/packages/react-atlas-core/src/Table/Table.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
-import { LightTable } from "light-table/src";
+import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
 
 class Table extends React.PureComponent {
   render() {
@@ -18,7 +18,7 @@ class Table extends React.PureComponent {
     } = this.props;
 
     return (
-      <LightTable
+      <BootstrapTable
         style={style}
         {...props}
         search={search}
@@ -33,7 +33,7 @@ class Table extends React.PureComponent {
         bodyContainerClass={"ra_Table__react-bs-container-body"}
       >
         {children}
-      </LightTable>
+      </BootstrapTable>
     );
   }
 }


### PR DESCRIPTION
…rap-table's latest for react-atlas-core only